### PR TITLE
assume initial inflated state for external values

### DIFF
--- a/modules/Rose-DB-Object/lib/Rose/DB/Object/Metadata/Column.pm
+++ b/modules/Rose-DB-Object/lib/Rose/DB/Object/Metadata/Column.pm
@@ -1048,7 +1048,7 @@ sub apply_method_triggers
           }
           else
           {
-            $self->{$is_inflated_key} = 0  unless($uses_formatted_key);
+            $self->{$is_inflated_key} = 1  unless($uses_formatted_key);
 
             my @ret;
 


### PR DESCRIPTION
Current code assume deflated state for values coming from database as well as from end-user code, and wrongly triggers inflate event when accessing this value, even without ever reaching database, as illustrated by the following test case:

```
#!/usr/bin/perl

use strict;
use warnings;
use v5.10;

package My::DB;
use base qw(Rose::DB);
__PACKAGE__->use_private_registry;
__PACKAGE__->register_db(
    driver   => 'mysql',
    host     => 'localhost',
    database => 'fake',
    username => 'fake',
    password => 'fake',
);

package My::Object;
use base qw(Rose::DB::Object);
use JSON;
__PACKAGE__->meta->setup(
    table => 'table',
    columns => [
        column => { type => 'scalar',  inflate => \&_inflate, deflate => \&_deflate },
    ]
);

sub init_db { My::DB->new() }
sub _deflate {
    my $self  = shift;
    my $value = shift;
    return $value ? encode_json($value) : undef;
}

sub _inflate {
    my $self  = shift;
    my $value = shift;
    return $value ? decode_json($value) : undef;
}

package main;

my $object = My::Object->new();
$object->column({ key => 'value' });
say $object->column();
```

This PR fixes this issue.