### PR TITLE
Adds corresponding HTML input types for Numeric and Integer Rose::HTML::Form::Field classes

### DIFF
--- a/modules/Rose-HTML-Objects/lib/Rose/HTML/Form/Field/Integer.pm
+++ b/modules/Rose-HTML-Objects/lib/Rose/HTML/Form/Field/Integer.pm
@@ -9,7 +9,7 @@ use base 'Rose::HTML::Form::Field::Numeric';
 our $VERSION = '0.606';
 
 __PACKAGE__->add_required_html_attrs({
-  type  => 'number',
+  step => 1,
 });
 
 

--- a/modules/Rose-HTML-Objects/lib/Rose/HTML/Form/Field/Integer.pm
+++ b/modules/Rose-HTML-Objects/lib/Rose/HTML/Form/Field/Integer.pm
@@ -8,6 +8,11 @@ use base 'Rose::HTML::Form::Field::Numeric';
 
 our $VERSION = '0.606';
 
+__PACKAGE__->add_required_html_attrs({
+  type  => 'number',
+});
+
+
 sub validate
 {
   my($self) = shift;

--- a/modules/Rose-HTML-Objects/lib/Rose/HTML/Form/Field/Numeric.pm
+++ b/modules/Rose-HTML-Objects/lib/Rose/HTML/Form/Field/Numeric.pm
@@ -15,6 +15,10 @@ our $VERSION = '0.606';
 
 __PACKAGE__->default_html_attr_value(size  => 6);
 
+__PACKAGE__->add_required_html_attrs({
+	type  => 'number',
+});
+
 sub positive
 {
   my($self) = shift;


### PR DESCRIPTION
Adds corresponding HTML input types for Numeric and Integer Rose::HTML::Form::Field classes.

This would make the result UX look better - switching the input types from the default text type to the number type. For the integer field class, the step=1 HTML attribute is also added to prevent the arrow controls from increasing/decreasing number by a default floating point value.