### PR TITLE
Pg: inline current_timestamp

### DIFF
--- a/modules/Rose-DB/lib/Rose/DB/Pg.pm
+++ b/modules/Rose-DB/lib/Rose/DB/Pg.pm
@@ -238,6 +238,8 @@ sub validate_timestamp_keyword
 
 *validate_datetime_keyword = \&validate_timestamp_keyword;
 
+sub should_inline_timestamp_keyword { 1 }
+
 sub server_time_zone
 {
   my($self) = shift;


### PR DESCRIPTION
Hi,

This PR opened to discuss a minor change. Our current object definitions for rose include the following:

    created => { type => 'timestamp', not_null => 1, default => 'CURRENT_TIMESTAMP' }

This works nicely for Oracle, but not Postgres.

However, if we were to change it to "now()", then it would work for Postgres (since now() is recognised as a function), but leave the object incompatible with Oracle. So, I'd like to discuss make timestamps inline for Postgres.

If the one liner PR is added to the code, then CURRENT_TIMESTAMP is seen as a value to be inlined, and our insert queries work nicely. 

More than happy to discuss if there is a better way.

Thanks,
Ferry