### PR TITLE
Call Rose::DB->refine_dbi_foreign_key_info at the end of Rose::DB::Pg…

### DIFF
--- a/modules/Rose-DB/lib/Rose/DB/Pg.pm
+++ b/modules/Rose-DB/lib/Rose/DB/Pg.pm
@@ -727,6 +727,8 @@ sub refine_dbi_foreign_key_info
     $fk_info->{'FK_TABLE_CAT'} = undef;
     $fk_info->{'UK_TABLE_CAT'} = undef;
   }
+
+   Rose::DB->refine_dbi_foreign_key_info($fk_info);
 }
 
 sub list_tables


### PR DESCRIPTION
…->refine_dbi_foreign_key_info

So that the general refining is done, too (e.g. unquote table names).

In our project we build the meta data classes by manually running a script. Since Rose::DB version 0.782, some of the foreign key meta data entries are missing. This happens for tables with names like reserved psql keywords (e.g. "user", "group"). It works for other names (eg. "clients"),
`DBI->foreign_key_info` returns such tables enclosed in double quotes and `Rose::DB->refine_dbi_foreign_key_info` used to remove these quotes.
But now the postgres driver code `Rose::DB::Pg->refine_dbi_foreign_key_info` overrides `Rose::DB->refine_dbi_foreign_key_info` and the quotes are not removed anymore.

This PR/commit calls `Rose::DB>refine_dbi_foreign_key_info` at the end of `Rose::DB::Pg->refine_dbi_foreign_key_info` to do the general refinement anyways.
